### PR TITLE
avoid -Wno-unused-parameter warning with NDEBUG builds

### DIFF
--- a/src/c-rbtree.c
+++ b/src/c-rbtree.c
@@ -460,6 +460,7 @@ _public_ void c_rbtree_move(CRBTree *to, CRBTree *from) {
         if (from->root) {
                 t = c_rbnode_pop_root(from->root);
                 assert(t == from);
+                (void)t;
 
                 to->root = from->root;
                 from->root = NULL;


### PR DESCRIPTION
    $ CFLAGS='-DNDEBUG -Wno-unused-parameter' meson build --warnlevel 2

    [2/16] Compiling C object 'src/25a6634@@crbtree-private@sta/c-rbtree.c.o'.
    ../src/c-rbtree.c: In function ‘c_rbtree_move’:
    ../src/c-rbtree.c:456:18: warning: variable ‘t’ set but not used [-Wunused-but-set-variable]
             CRBTree *t;
                      ^

---

See also: https://github.com/nettools/n-acd/pull/6