### PR TITLE
fix build on m68k/sh4 archs and require minimal struct aligment to only 4 bytes

### DIFF
--- a/src/c-rbtree-private.h
+++ b/src/c-rbtree-private.h
@@ -18,12 +18,12 @@ static inline void *c_rbnode_raw(CRBNode *n) {
         return (void *)(n->__parent_and_flags & ~C_RBNODE_FLAG_MASK);
 }
 
-static inline unsigned long c_rbnode_flags(CRBNode *n) {
+static inline uintptr_t c_rbnode_flags(CRBNode *n) {
         return n->__parent_and_flags & C_RBNODE_FLAG_MASK;
 }
 
 static inline _Bool c_rbnode_is_red(CRBNode *n) {
-        return c_rbnode_flags(n) & C_RBNODE_RED;
+        return !!(c_rbnode_flags(n) & C_RBNODE_RED);
 }
 
 static inline _Bool c_rbnode_is_black(CRBNode *n) {
@@ -31,5 +31,5 @@ static inline _Bool c_rbnode_is_black(CRBNode *n) {
 }
 
 static inline _Bool c_rbnode_is_root(CRBNode *n) {
-        return c_rbnode_flags(n) & C_RBNODE_ROOT;
+        return !!(c_rbnode_flags(n) & C_RBNODE_ROOT);
 }

--- a/src/c-rbtree.c
+++ b/src/c-rbtree.c
@@ -31,15 +31,15 @@
 #include "c-rbtree-private.h"
 
 /*
- * We use alignas(8) to enforce 64bit alignment of structure fields. This is
+ * We use alignas() to enforce at least 32 bit alignment of structure fields. This is
  * according to ISO-C11, so we rely on the compiler to implement this. However,
  * at the same time we don't want to exceed native malloc() alignment on target
  * platforms. Hence, we also verify against max_align_t.
  */
 static_assert(alignof(CRBNode) <= alignof(max_align_t), "Invalid RBNode alignment");
-static_assert(alignof(CRBNode) >= 8, "Invalid CRBNode alignment");
+static_assert(alignof(CRBNode) >= 4, "Invalid CRBNode alignment");
 static_assert(alignof(CRBTree) <= alignof(max_align_t), "Invalid RBTree alignment");
-static_assert(alignof(CRBTree) >= 8, "Invalid CRBTree alignment");
+static_assert(alignof(CRBTree) >= 4, "Invalid CRBTree alignment");
 
 /**
  * c_rbnode_leftmost() - return leftmost child
@@ -363,8 +363,8 @@ static inline void c_rbtree_store(CRBNode **ptr, CRBNode *addr) {
  * applied. But since both fields share its backing memory, this helper
  * function is provided.
  */
-static inline void c_rbnode_set_parent_and_flags(CRBNode *n, CRBNode *p, unsigned long flags) {
-        n->__parent_and_flags = (unsigned long)p | flags;
+static inline void c_rbnode_set_parent_and_flags(CRBNode *n, CRBNode *p, uintptr_t flags) {
+        n->__parent_and_flags = ((uintptr_t)(void *)p) | flags;
 }
 
 /*
@@ -403,7 +403,7 @@ static inline CRBTree *c_rbnode_pop_root(CRBNode *n) {
 static inline CRBTree *c_rbnode_push_root(CRBNode *n, CRBTree *t) {
         if (t) {
                 if (n)
-                        n->__parent_and_flags = (unsigned long)t
+                        n->__parent_and_flags = ((uintptr_t)(void *)t)
                                                 | c_rbnode_flags(n)
                                                 | C_RBNODE_ROOT;
                 c_rbtree_store(&t->root, n);

--- a/src/c-rbtree.h
+++ b/src/c-rbtree.h
@@ -29,15 +29,15 @@ extern "C" {
 #include <assert.h>
 #include <stdalign.h>
 #include <stddef.h>
+#include <stdint.h>
 
 typedef struct CRBNode CRBNode;
 typedef struct CRBTree CRBTree;
 
 /* implementation detail */
-#define C_RBNODE_RED                    (0x1UL)
-#define C_RBNODE_ROOT                   (0x2UL)
-#define C_RBNODE_UNUSED3                (0x4UL)
-#define C_RBNODE_FLAG_MASK              (0x7UL)
+#define C_RBNODE_RED                    ((uintptr_t)0x1U)
+#define C_RBNODE_ROOT                   ((uintptr_t)0x2U)
+#define C_RBNODE_FLAG_MASK              ((uintptr_t)0x3U)
 
 /**
  * struct CRBNode - Node of a Red-Black Tree
@@ -60,12 +60,12 @@ typedef struct CRBTree CRBTree;
  * C_RBNODE_INIT.
  */
 struct CRBNode {
-        alignas(8) unsigned long __parent_and_flags;
+        alignas(sizeof(uintptr_t) > 4 ? sizeof(uintptr_t) : 4) uintptr_t __parent_and_flags;
         CRBNode *left;
         CRBNode *right;
 };
 
-#define C_RBNODE_INIT(_var) { .__parent_and_flags = (unsigned long)&(_var) }
+#define C_RBNODE_INIT(_var) { .__parent_and_flags = ((uintptr_t)(void *)&(_var)) }
 
 CRBNode *c_rbnode_leftmost(CRBNode *n);
 CRBNode *c_rbnode_rightmost(CRBNode *n);
@@ -90,7 +90,7 @@ void c_rbnode_unlink_stale(CRBNode *n);
  * To initialize an RB-Tree, set it to NULL / all zero.
  */
 struct CRBTree {
-        alignas(8) CRBNode *root;
+        alignas(sizeof(uintptr_t) > 4 ? sizeof(uintptr_t) : 4) CRBNode *root;
 };
 
 #define C_RBTREE_INIT {}


### PR DESCRIPTION
Building on m68k and sh4 architectures fails with static assertions:

```
    shared/c-rbtree/src/c-rbtree.c:39:1: error: static assertion failed: "Invalid RBNode alignment"
       39 | static_assert(alignof(CRBNode) <= alignof(max_align_t), "Invalid RBNode alignment");
          | ^~~~~~~~~~~~~
    shared/c-rbtree/src/c-rbtree.c:41:1: error: static assertion failed: "Invalid RBTree alignment"
       41 | static_assert(alignof(CRBTree) <= alignof(max_align_t), "Invalid RBTree alignment");
          | ^~~~~~~~~~~~~
    make[3]: *** [Makefile:13261: shared/c-rbtree/src/libcrbtree_la-c-rbtree.lo] Error 1
    make[3]: *** Waiting for unfinished jobs....
```

I presume that is, because on those architectures "max_align_t" is only aligned to 4 bytes.

The previous alignment to 8 bytes was to reserve 4 flags, and ensure that all valid
pointers have these lower bits unset. Since one flag was actually unused, we only
need to reserve 3 bits and can accept an alignment to 4 bytes only.

Also, while at it don't use "unsigned long" but uintptr_t type. Since this is supposed to
be a C11 library, we can rely on <stdint.h> to provide that type for us (on any architecture
we care about).

This is an ABI break, but I think that is acceptable, since c-rbtree is
usually statically linked.

---

I didn't actually tested this patch as I don't have access to such a system. So it might not be the right fix, but that I would only see after another NetworkManger release (or release candidate). You can see the build failures here for NetworkManager 1.27.90-1 package: https://buildd.debian.org/status/package.php?p=network-manager