### PR TITLE
c-rbtree: fix struct alignment of CRBTree on m68k architectures

### DIFF
--- a/src/c-rbtree.h
+++ b/src/c-rbtree.h
@@ -27,6 +27,7 @@ extern "C" {
 #endif
 
 #include <assert.h>
+#include <stdalign.h>
 #include <stddef.h>
 
 typedef struct CRBNode CRBNode;
@@ -58,7 +59,10 @@ typedef struct CRBTree CRBTree;
  * C_RBNODE_INIT.
  */
 struct CRBNode {
-        unsigned long __parent_and_flags;
+        union {
+                unsigned long __parent_and_flags;
+                alignas(4) char __dmmy_for_struct_alignment;
+        };
         CRBNode *left;
         CRBNode *right;
 };


### PR DESCRIPTION
On m68k, 32bit integer are aligned only to 2 bytes. This breaks
assumptions and a static assertion of c-rbtree.

Explicitly require that the first field is aligned to at least 4 bytes.
This fixes the build and ensures that all pointers have the lowest two
bits unset (so they can be used for storing 2 additional flags).

Use a union instead of aligning __parent_and_flags itself. That is
because alignas() cannot lower the natural alignment, so if we would
want to align __parent_and_flags, we could only do
```
  alignas(sizeof(unsigned long) > 4 ? sizeof(unsigned long) : 4)
```
That would not be correct if "long" is 8 bytes long but had a natural
alignment of only 4. The union allows us to really choose the
minimal alignment.

---

follow up for https://github.com/c-util/c-rbtree/pull/4#issuecomment-706725775