### PR TITLE
meson: no longer pass -Wl,--no-undefined explicitly

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -10,7 +10,6 @@ libcrbtree_deps = [
 
 if use_noundefined
         libcrbtree_lflags = [
-                '-Wl,--no-undefined',
                 '-Wl,--version-script=@0@'.format(libcrbtree_symfile),
         ]
 else


### PR DESCRIPTION
to make it possible to build dbus-broker with clang and ASan/UBsan
on OSS-Fuzz (https://github.com/google/oss-fuzz/pull/7860) without
sed scripts.

-Wl,--no-undefined is still passed by meson by default unless -Db_lundef
is set to false explictily.

https://github.com/mesonbuild/meson/issues/764